### PR TITLE
add support for multi-line values with \

### DIFF
--- a/read.go
+++ b/read.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/warnings.v0"
 )
 
-var unescape = map[rune]rune{'\\': '\\', '"': '"', 'n': '\n', 't': '\t', 'b': '\b'}
+var unescape = map[rune]rune{'\\': '\\', '"': '"', 'n': '\n', 't': '\t', 'b': '\b', '\n': '\n'}
 
 // no error: invalid literals should be caught by scanner
 func unquote(s string) string {

--- a/read_test.go
+++ b/read_test.go
@@ -399,6 +399,10 @@ func TestReadWithCallback(t *testing.T) {
 	key5=
 	[sect1 "subsect2"]
 	[sect2]
+	[sect3]
+    foo = "!f(){ \
+	echo hello; \
+	};f"
 	`
 	expected := [][]string{
 		[]string{"sect1", "", "", "", "true"},
@@ -410,6 +414,8 @@ func TestReadWithCallback(t *testing.T) {
 		[]string{"sect1", "subsect1", "key5", "", "false"},
 		[]string{"sect1", "subsect2", "", "", "true"},
 		[]string{"sect2", "", "", "", "true"},
+		[]string{"sect3", "", "", "", "true"},
+		[]string{"sect3", "", "foo", "!f(){ \n\techo hello; \n\t};f", "false"},
 	}
 	err := ReadWithCallback(bytes.NewReader([]byte(text)), cb)
 	if err != nil {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -163,12 +163,13 @@ func (s *Scanner) scanIdentifier() string {
 	return string(s.src[offs:s.offset])
 }
 
+// val indicate if we are scanning a value (vs a header)
 func (s *Scanner) scanEscape(val bool) {
 	offs := s.offset
 	ch := s.ch
 	s.next() // always make progress
 	switch ch {
-	case '\\', '"':
+	case '\\', '"', '\n':
 		// ok
 	case 'n', 't', 'b':
 		if val {


### PR DESCRIPTION
This is explicitely valid as per https://git-scm.com/docs/git-config#_syntax
> A line that defines a value can be continued to the next line by ending it with a \\;